### PR TITLE
Copy plugins into correct location

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,8 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
-    maxParallel: 8
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -11,7 +11,6 @@ jobs:
       osx_64_:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
-    maxParallel: 8
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -11,7 +11,6 @@ jobs:
       win_64_:
         CONFIG: win_64_
         UPLOAD_PACKAGES: 'True'
-    maxParallel: 4
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\
@@ -53,7 +52,7 @@ jobs:
 
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=3 pip' # Optional
+        packageSpecs: 'python=3.6 conda-build conda "conda-forge-ci-setup=3" pip' # Optional
         installOptions: "-c conda-forge"
         updateConda: true
       displayName: Install conda-build and activate environment

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -4,6 +4,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -13,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 hdf5:
 - 1.10.6
 lz4_c:
@@ -25,3 +27,6 @@ pin_run_as_build:
     max_pin: x.x.x
 target_platform:
 - linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -27,3 +27,6 @@ pin_run_as_build:
     max_pin: x.x.x
 target_platform:
 - osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -74,6 +74,8 @@ docker run ${DOCKER_RUN_ARGS} \
            -e CI \
            -e FEEDSTOCK_NAME \
            -e CPU_COUNT \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e BUILD_OUTPUT_ID \
            -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -23,7 +23,7 @@ source ${HOME}/miniforge3/etc/profile.d/conda.sh
 conda activate base
 
 echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
-conda install -n base --quiet --yes conda-forge-ci-setup=3 conda-build pip
+conda install -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip
 
 
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: https://github.com/nexusformat/HDF5-External-Filter-Plugins
 
 Package license: MIT AND LicenseRef-HDF5 AND BSD-3-Clause
 
-Feedstock license: BSD-3-Clause
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/hdf5-external-filter-plugins-feedstock/blob/master/LICENSE.txt)
 
 Summary: Provides dynamically loadable compression filters for HDF5 that are
 popular for photon or neutron science

--- a/build-locally.py
+++ b/build-locally.py
@@ -12,6 +12,10 @@ from argparse import ArgumentParser
 def setup_environment(ns):
     os.environ["CONFIG"] = ns.config
     os.environ["UPLOAD_PACKAGES"] = "False"
+    if ns.debug:
+        os.environ["BUILD_WITH_CONDA_DEBUG"] = "1"
+        if ns.output_id:
+            os.environ["BUILD_OUTPUT_ID"] = ns.output_id
 
 
 def run_docker_build(ns):
@@ -51,6 +55,14 @@ def verify_config(ns):
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--debug",
+        action="store_true",
+        help="Setup debug environment using `conda debug`",
+    )
+    p.add_argument(
+        "--output-id", help="If running debug, specify the output to setup."
+    )
 
     ns = p.parse_args(args=args)
     verify_config(ns)

--- a/recipe/build-bitshuffle.bat
+++ b/recipe/build-bitshuffle.bat
@@ -8,3 +8,6 @@ cmake ^
   -DCMAKE_INSTALL_PREFIX=%PREFIX% ^
   -G"Visual Studio %VS_MAJOR% %VS_YEAR% Win64" || exit /b 1
 cmake --build . --target INSTALL || exit /b 1
+
+mkdir %PREFIX%\lib\hdf5\plugin
+copy %PREFIX%\lib\plugins\h5bshuf.dll %PREFIX%\lib\hdf5\plugin || exit /b 1

--- a/recipe/build-bitshuffle.sh
+++ b/recipe/build-bitshuffle.sh
@@ -12,3 +12,6 @@ cmake \
   -DCMAKE_INSTALL_LIBDIR=lib \
   -DCMAKE_INSTALL_PREFIX=$PREFIX
 make install
+
+mkdir -p $PREFIX/lib/hdf5/plugin
+cp $PREFIX/lib/plugins/libh5bshuf.so $PREFIX/lib/hdf5/plugin

--- a/recipe/build-bitshuffle.sh
+++ b/recipe/build-bitshuffle.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eu
 
 mkdir -p build
 cd build
@@ -9,5 +10,5 @@ cmake \
   -DENABLE_LZ4_PLUGIN=no \
   -DENABLE_BZIP2_PLUGIN=no \
   -DCMAKE_INSTALL_LIBDIR=lib \
-  -DCMAKE_INSTALL_PREFIX=$PREFIX \
-&& make install
+  -DCMAKE_INSTALL_PREFIX=$PREFIX
+make install

--- a/recipe/build-bzip2.bat
+++ b/recipe/build-bzip2.bat
@@ -8,3 +8,6 @@ cmake ^
   -DCMAKE_INSTALL_PREFIX=%PREFIX% ^
   -G"Visual Studio %VS_MAJOR% %VS_YEAR% Win64" || exit /b 1
 cmake --build . --target INSTALL || exit /b 1
+
+mkdir %PREFIX%\lib\hdf5\plugin
+copy %PREFIX%\lib\plugins\h5bz2.dll %PREFIX%\lib\hdf5\plugin || exit /b 1

--- a/recipe/build-bzip2.sh
+++ b/recipe/build-bzip2.sh
@@ -12,3 +12,6 @@ cmake \
   -DCMAKE_INSTALL_LIBDIR=lib \
   -DCMAKE_INSTALL_PREFIX=$PREFIX
 make install
+
+mkdir -p $PREFIX/lib/hdf5/plugin
+cp $PREFIX/lib/plugins/libh5bz2.so $PREFIX/lib/hdf5/plugin

--- a/recipe/build-bzip2.sh
+++ b/recipe/build-bzip2.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eu
 
 mkdir -p build
 cd build
@@ -9,5 +10,5 @@ cmake \
   -DENABLE_LZ4_PLUGIN=no \
   -DENABLE_BZIP2_PLUGIN=yes \
   -DCMAKE_INSTALL_LIBDIR=lib \
-  -DCMAKE_INSTALL_PREFIX=$PREFIX \
-&& make install
+  -DCMAKE_INSTALL_PREFIX=$PREFIX
+make install

--- a/recipe/build-lz4.bat
+++ b/recipe/build-lz4.bat
@@ -8,3 +8,6 @@ cmake ^
   -DCMAKE_INSTALL_PREFIX=%PREFIX% ^
   -G"Visual Studio %VS_MAJOR% %VS_YEAR% Win64" || exit /b 1
 cmake --build . --target INSTALL || exit /b 1
+
+mkdir %PREFIX%\lib\hdf5\plugin
+copy %PREFIX%\lib\plugins\h5lz4.dll %PREFIX%\lib\hdf5\plugin || exit /b 1

--- a/recipe/build-lz4.sh
+++ b/recipe/build-lz4.sh
@@ -12,3 +12,6 @@ cmake \
   -DCMAKE_INSTALL_LIBDIR=lib \
   -DCMAKE_INSTALL_PREFIX=$PREFIX
 make install
+
+mkdir -p $PREFIX/lib/hdf5/plugin
+cp $PREFIX/lib/plugins/libh5lz4.so $PREFIX/lib/hdf5/plugin

--- a/recipe/build-lz4.sh
+++ b/recipe/build-lz4.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eu
 
 mkdir -p build
 cd build
@@ -9,5 +10,5 @@ cmake \
   -DENABLE_LZ4_PLUGIN=yes \
   -DENABLE_BZIP2_PLUGIN=no \
   -DCMAKE_INSTALL_LIBDIR=lib \
-  -DCMAKE_INSTALL_PREFIX=$PREFIX \
-&& make install
+  -DCMAKE_INSTALL_PREFIX=$PREFIX
+make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,9 @@ outputs:
       commands:
         - conda inspect linkages -p $PREFIX {{ name|lower + '-bitshuffle' }}  # [not win]
         - test -f $PREFIX/lib/plugins/libh5bshuf.so                           # [not win]
+        - test -f $PREFIX/lib/hdf5/plugin/libh5bshuf.so                       # [not win]
         - if not exist %PREFIX%\\lib\\plugins\\h5bshuf.dll exit 1             # [win]
+        - if not exist %PREFIX%\\lib\\hdf5\\plugin\\h5bshuf.dll exit 1        # [win]
 
   - name: {{ name|lower + '-bzip2' }}
     requirements:
@@ -63,7 +65,9 @@ outputs:
       commands:
         - conda inspect linkages -p $PREFIX {{ name|lower + '-bzip2' }}  # [not win]
         - test -f $PREFIX/lib/plugins/libh5bz2.so                        # [not win]
+        - test -f $PREFIX/lib/hdf5/plugin/libh5bz2.so                    # [not win]
         - if not exist %PREFIX%\\lib\\plugins\\h5bz2.dll exit 1          # [win]
+        - if not exist %PREFIX%\\lib\\hdf5\\plugin\\h5bz2.dll exit 1     # [win]
 
   - name: {{ name|lower + '-lz4' }}
     requirements:
@@ -84,7 +88,9 @@ outputs:
       commands:
         - conda inspect linkages -p $PREFIX {{ name|lower + '-lz4' }}  # [not win]
         - test -f $PREFIX/lib/plugins/libh5lz4.so                      # [not win]
+        - test -f $PREFIX/lib/hdf5/plugin/libh5lz4.so                  # [not win]
         - if not exist %PREFIX%\\lib\\plugins\\h5lz4.dll exit 1        # [win]
+        - if not exist %PREFIX%\\lib\\hdf5\\plugin\\h5lz4.dll exit 1   # [win]
 
 about:
   home: https://github.com/nexusformat/HDF5-External-Filter-Plugins

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -105,8 +105,6 @@ about:
     core library without recompiling your application. This package
     provides external filters for HDF5 for the Bitshuffle, BZIP2,
     and LZ4 compression algorithms.
-  doc_url: https://github.com/nexusformat/HDF5-External-Filter-Plugins
-  dev_url: https://github.com/nexusformat/HDF5-External-Filter-Plugins
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - patches/0002-Do-not-distribute-VC-runtimes.patch  # [win]
 
 build:
-  number: 4
+  number: 5
 
 requirements:
   run:


### PR DESCRIPTION
HDF5 expects plugins in `lib/hdf5/plugin`, not `lib/plugins`. Doing this correctly avoids the need to set environment variables (and thus closes #6)

This PR copies files into both locations for backwards compatibility.
In the next version update (if there ever is another version) we should remove the files at the `lib/plugins` location.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
